### PR TITLE
Unshare Unit and Context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,8 +1289,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "rune"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996fe2e9f814db578e6a5f4d3c63791c90d030040bdb58ca8e367c3ed7b7e8e9"
+source = "git+https://github.com/pkolaczk/rune/?branch=cloneable-unit-and-context#5d778585da08031f904f53fe48cd2e6e6ba241a6"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1315,8 +1314,7 @@ dependencies = [
 [[package]]
 name = "rune-macros"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a4a9e848538bfed0281b47a0af878e81c7cc87fcedaef4d5ea275c7f3db5b9"
+source = "git+https://github.com/pkolaczk/rune/?branch=cloneable-unit-and-context#5d778585da08031f904f53fe48cd2e6e6ba241a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ num_cpus = "1.13.0"
 parse_duration = "2.1.1"
 rand = "0.7.3"
 regex = "1.5.4"
-rune = "0.10.0"
+rune = { git = "https://github.com/pkolaczk/rune/", branch = "cloneable-unit-and-context" }
 scylla = "0.3.1"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.57"
@@ -46,16 +46,12 @@ uuid = { version = "0.8", features = ["v4"] }
 tokio = { version = "1.11", features = ["rt", "test-util", "macros"] }
 
 [profile.release]
-opt-level = 3
 lto = true
-debug = true
 panic = "abort"
 
-[profile.release-no-lto]
-inherits = "release"
-opt-level = 3
-lto = false
-debug = true
+[profile.dev-opt]
+inherits = "dev"
+opt-level = 2
 
 [package.metadata.deb]
 maintainer = "Piotr Kołaczkowski <pkolaczk@gmail.com>"

--- a/src/deadline.rs
+++ b/src/deadline.rs
@@ -1,10 +1,8 @@
+use crate::config;
 use std::cmp;
 use std::ops::Range;
-use crate::config;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::time::Instant;
-
-
 
 /// Decides when to stop benchmark execution.
 pub enum Deadline {
@@ -45,7 +43,10 @@ impl Deadline {
             Deadline::FixedTime { current, deadline } => {
                 if Instant::now() < *deadline {
                     let start = current.fetch_add(BATCH_SIZE, Ordering::Relaxed);
-                    Range { start, end: start + BATCH_SIZE }
+                    Range {
+                        start,
+                        end: start + BATCH_SIZE,
+                    }
                 } else {
                     Range::default()
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,7 +402,6 @@ async fn run(conf: RunCommand) -> Result<()> {
         }
     }
 
-    let program = Arc::new(program);
     let loader = Workload::new(session.clone(), program.clone(), FnRef::new(LOAD_FN));
     let runner = Workload::new(session.clone(), program.clone(), FnRef::new(RUN_FN));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ async fn run_stream(
 
     let mut result_stream = stream
         .take_while(|i| ready(!i.is_empty()))
-        .flat_map(|range| futures::stream::iter(range))
+        .flat_map(futures::stream::iter)
         // unconstrained to workaround quadratic complexity of buffer_unordered ()
         .map(|i| tokio::task::unconstrained(workload.run(i as i64)))
         .buffer_unordered(concurrency.get())


### PR DESCRIPTION
By not sharing Rune stuff we waste a bit of memory,
but we allow each task to run independently.
Rune uses Arc heavily, and they become a bottleneck
on multicore computers.

Running empty benchmark on 24 cores:
before: 1,403,487 calls per second
after: 30,981,323 calls per second

Fixes #9