### PR TITLE
Fix recording of the last snapshot cycle count and time

### DIFF
--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -38,15 +38,15 @@ impl<'a> Sampler<'a> {
 
     /// Should be called when a workload iteration finished.
     /// If there comes the time, it will send the stats to the output.
-    pub async fn cycle_completed(&mut self, iteration: u64, now: Instant) {
+    pub async fn cycle_completed(&mut self, cycle: u64, now: Instant) {
         let current_interval_duration = now - self.last_snapshot_time;
-        let current_interval_iter_count = iteration - self.last_snapshot_cycle;
+        let current_interval_cycle_count = cycle - self.last_snapshot_cycle;
 
         // Don't snapshot if we're too close to the end of the run,
         // to avoid excessively small samples:
         let far_from_the_end = match self.run_duration {
             config::Interval::Time(d) => now < self.start_time + d - current_interval_duration / 2,
-            config::Interval::Count(count) => iteration < count - current_interval_iter_count / 2,
+            config::Interval::Count(count) => cycle < count - current_interval_cycle_count / 2,
             config::Interval::Unbounded => true,
         };
 
@@ -54,12 +54,21 @@ impl<'a> Sampler<'a> {
             Interval::Time(d) => {
                 if now > self.last_snapshot_time + d && far_from_the_end {
                     self.send_stats().await;
+                    // We may be running this slightly too late,
+                    // so set the perfect time of the sample, so the next sample is slightly shorter.
+                    // This way we avoid increasing the lag.
                     self.last_snapshot_time += d;
+                    self.last_snapshot_cycle = cycle;
                 }
             }
             Interval::Count(cnt) => {
-                if iteration > self.last_snapshot_cycle + cnt && far_from_the_end {
+                if cycle > self.last_snapshot_cycle + cnt && far_from_the_end {
                     self.send_stats().await;
+                    self.last_snapshot_time = now;
+                    // Similarly like with time, we might have been called
+                    // when the counter already went a bit further than the target split point,
+                    // so let's record the perfect (desired) cycle count so we don't
+                    // increase the lag.
                     self.last_snapshot_cycle += cnt;
                 }
             }


### PR DESCRIPTION
Some information about the last snapshot point was
not recorded properly in the Sampler which in some cases
led to `far_from_the_end` variable turn to false too early
and new samples were not emitted anymore.

Fixes #27