### PR TITLE
Add UDT support for prepared statements

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -393,6 +393,37 @@ mod bind {
                 let elements = v.as_ref().iter().map(to_scylla_value).try_collect()?;
                 Ok(CqlValue::List(elements))
             }
+            Value::Object(v) => {
+                let borrowed = v.borrow_ref().unwrap();
+
+                // // Get value of "_keyspace" key or set default value
+                let keyspace = match borrowed.get_value::<str, String>("_keyspace") {
+                    Ok(Some(value)) => value,
+                    _ => "unknown".to_string(),
+                };
+
+                // // Get value of "_type_name" key or set default value
+                let type_name = match borrowed.get_value::<str, String>("_type_name") {
+                    Ok(Some(value)) => value,
+                    _ => "unknown".to_string(),
+                };
+
+                let keys = borrowed.keys();
+                let values: Result<Vec<Option<CqlValue>>, _> = borrowed.values()
+                    .map(|value| to_scylla_value(&value.clone())
+                    .map(Some)).collect();
+                let fields: Vec<(String, Option<CqlValue>)> = keys.into_iter()
+                    .zip(values?.into_iter())
+                    .filter(|&(key, _)| key != "_keyspace" && key != "_type_name")
+                    .map(|(key, value)| (key.to_string(), value))
+                    .collect();
+                let udt = CqlValue::UserDefinedType{
+                    keyspace: keyspace,
+                    type_name: type_name,
+                    fields: fields,
+                };
+                Ok(udt)
+            },
             Value::Any(obj) => {
                 let obj = obj.borrow_ref().unwrap();
                 let h = obj.type_hash();


### PR DESCRIPTION
Update the latte's `to_scylla_value` function (which is used by the `execute_prepared` one) to support `CQL UserDefinedType`s.

If we create UDT like following:

```
  let KEYSPACE = "fooks"
  let UDT_NAME = "fooudt"
  context.execute(`CREATE TYPE IF NOT EXISTS ${KEYSPACE}.${UDT_NAME} (
    id bigint, textk1 text, textk2 text)`).await?;
```

And then use it in some table.
Then, with this change, we can use the `rune::runtime::Object` object defined like following:

```
  let udtexample = #{
    "_keyspace": KEYSPACE, "_type_name": UDT_NAME,
    "id": fooid, "textk1": textv1, "textk2": textv2
  };
```

in an `execute_prepared` function.

Note that `_keyspace` and `_type_name` are special and required fields which are used to satisfy the Scylla Rust driver's `CqlValue::UserDefinedType` object structure:

```
  pub enum CqlValue {
    ...
    UserDefinedType {
        keyspace: String,
        type_name: String,
        /// Order of `fields` vector must match the order of fields as defined in the UDT. The
        /// driver does not check it by itself, so incorrect data will be written if the order is
        /// wrong.
        fields: Vec<(String, Option<CqlValue>)>,
    },
    ...
```

Also, note that for proper workability of various sub-types of the UDT
such as `bigint` for the example `id` field mentioned above need to use
Scylla-rust driver `0.11` or newer.

Closes: #57