### PR TITLE
Add 'now_timestamp' latte function to be used in rune scripts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,7 @@ use std::io::{BufRead, BufReader, ErrorKind, Read};
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use chrono::Utc;
 use hdrhistogram::Histogram;
 use itertools::Itertools;
 use metrohash::{MetroHash128, MetroHash64};
@@ -579,6 +580,11 @@ pub fn blob(seed: i64, len: usize) -> rune::runtime::Bytes {
     let mut rng = StdRng::seed_from_u64(seed as u64);
     let v = (0..len).map(|_| rng.gen()).collect_vec();
     rune::runtime::Bytes::from_vec(v)
+}
+
+/// Generates 'now' timestamp
+pub fn now_timestamp() -> i64 {
+    Utc::now().timestamp()
 }
 
 /// Selects one item from the collection based on the hash of the given value.

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -128,6 +128,7 @@ impl Program {
 
         let mut latte_module = Module::with_crate("latte");
         latte_module.function(&["blob"], context::blob).unwrap();
+        latte_module.function(&["now_timestamp"], context::now_timestamp).unwrap();
         latte_module.function(&["hash"], context::hash).unwrap();
         latte_module.function(&["hash2"], context::hash2).unwrap();
         latte_module


### PR DESCRIPTION
Useful when need to utilize the 'USING TIMESTAMP' Cql feature.

Can be utilized like the following in a rune script:

```
  latte::now_timestamp()
```