### PR TITLE
Add `text` latte function for getting random strings in rune scripts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -613,6 +613,17 @@ pub fn blob(seed: i64, len: usize) -> rune::runtime::Bytes {
     rune::runtime::Bytes::from_vec(v)
 }
 
+/// Generates random string of given length.
+/// Parameter `seed` is used to seed the RNG.
+pub fn text(seed: i64, len: usize) -> rune::runtime::StaticString {
+    let mut rng = StdRng::seed_from_u64(seed as u64);
+    let s: String = (0..len).map(|_| {
+        let code_point = rng.gen_range(0x0061u32..=0x007Au32); // Unicode range for 'a-z'
+        std::char::from_u32(code_point).unwrap()
+    }).collect();
+    rune::runtime::StaticString::new(s)
+}
+
 /// Generates 'now' timestamp
 pub fn now_timestamp() -> i64 {
     Utc::now().timestamp()

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -128,6 +128,7 @@ impl Program {
 
         let mut latte_module = Module::with_crate("latte");
         latte_module.function(&["blob"], context::blob).unwrap();
+        latte_module.function(&["text"], context::text).unwrap();
         latte_module.function(&["now_timestamp"], context::now_timestamp).unwrap();
         latte_module.function(&["hash"], context::hash).unwrap();
         latte_module.function(&["hash2"], context::hash2).unwrap();


### PR DESCRIPTION
Usage is as following:

```
  pub async fn load(ctxt, i) {
    ...
    let randomstring = latte::text(i, 64);
    ...
```