### PR TITLE
Add retry mechanism

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,6 @@ fn find_workload(workload: &Path) -> PathBuf {
 async fn connect(conf: &ConnectionConf) -> Result<(Context, Option<ClusterInfo>)> {
     eprintln!("info: Connecting to {:?}... ", conf.addresses);
     let session = context::connect(conf).await?;
-    let session = Context::new(session);
     let cluster_info = session.cluster_info().await?;
     eprintln!(
         "info: Connected to {} running Cassandra version {}",


### PR DESCRIPTION
With this change it is now possible to configure retry approach for queries.
Following new options are available:

    --retry-number=10
    --retry-interval=200ms | --retry-interval=100ms,3s
    --request-timeout=5

The `--retry-number` option allows to configure number of retries to be applied
in case of query failures. Default is `10`.

The `--retry-interval` option may store one or two time values separated with comma.
Values may have `ms` (milliseconds), `s` (seconds) units.
If 2 are specified then it will be `minimum` and `maximum` waiting interval
with exponential growth based on the made attempts. Default is `100ms,5s`.

The `--request-timeout` allows to configure the time for a query after which
it is considered as 'failed'. Measured in seconds. Default is `5`.

Print only 5 retry error messages per sample interval.
Also, hide long `string` and `blob` values from the retry error messages.

Closes: https://github.com/pkolaczk/latte/issues/60