### PR TITLE
Use Option for datacenter to keep backwards compatibility

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,8 +182,8 @@ pub struct ConnectionConf {
     pub ssl_key_file: Option<PathBuf>,
 
     /// Datacenter name
-    #[clap(long("datacenter"), required = false, default_value = "")]
-    pub datacenter: String,
+    #[clap(long("datacenter"), required = false)]
+    pub datacenter: Option<String>,
 
     /// Default CQL query consistency level
     #[clap(long("consistency"), required = false, default_value = "LOCAL_QUORUM")]

--- a/src/context.rs
+++ b/src/context.rs
@@ -62,8 +62,7 @@ fn ssl_context(conf: &&ConnectionConf) -> Result<Option<SslContext>, CassError> 
 /// Configures connection to Cassandra.
 pub async fn connect(conf: &ConnectionConf) -> Result<Context, CassError> {
     let mut policy_builder = DefaultPolicy::builder().token_aware(true);
-    let dc = &conf.datacenter;
-    if !dc.is_empty() {
+    if let Some(dc) = &conf.datacenter {
         policy_builder = policy_builder
             .prefer_datacenter(dc.to_owned())
             .permit_dc_failover(true);

--- a/src/report.rs
+++ b/src/report.rs
@@ -512,7 +512,9 @@ impl<'a> Display for RunConfigCmp<'a> {
         }
 
         let lines: Vec<Box<dyn Display>> = vec![
-            self.line("Datacenter", "", |conf| conf.connection.datacenter.clone()),
+            self.line("Datacenter", "", |conf| {
+                conf.connection.datacenter.clone().unwrap_or_default()
+            }),
             self.line("Consistency", "", |conf| {
                 conf.connection.consistency.scylla_consistency().to_string()
             }),


### PR DESCRIPTION
Adding non-optional datacenter field to the config made it impossible to load old reports.