### PR TITLE
New command: `latte list` for tabular listing of run results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "tracing-subscriber",
  "try-lock",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -2451,9 +2452,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 try-lock = "0.2.3"
 uuid = { version = "1.1", features = ["v4"] }
+walkdir = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "test-util", "macros"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,6 +466,29 @@ impl RunCommand {
 }
 
 #[derive(Parser, Debug)]
+pub struct ListCommand {
+    /// Lists only the runs of specified workload.
+    #[clap()]
+    pub workload: Option<String>,
+
+    /// Lists only the runs of given function.
+    #[clap(long, short('f'))]
+    pub function: Option<String>,
+
+    /// Lists only the runs with specified tags.
+    #[clap(long("tag"), number_of_values = 1)]
+    pub tags: Vec<String>,
+
+    /// Path to JSON reports directory where the JSON reports were written to.
+    #[clap(long, short('o'), long, default_value = ".", number_of_values = 1)]
+    pub output: Vec<PathBuf>,
+
+    /// Descends into subdirectories recursively.
+    #[clap(short('r'), long)]
+    pub recursive: bool,
+}
+
+#[derive(Parser, Debug)]
 pub struct ShowCommand {
     /// Path to the JSON report file
     #[clap(value_name = "PATH")]
@@ -544,6 +567,10 @@ pub enum Command {
     /// Prints nicely formatted statistics to the standard output.
     /// Additionally dumps all data into a JSON report file.
     Run(RunCommand),
+
+    /// Lists benchmark reports saved in the current or specified directory
+    /// with summaries of their results.
+    List(ListCommand),
 
     /// Displays the report(s) of previously executed benchmark(s).
     ///

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,0 +1,155 @@
+use console::style;
+use std::fmt::{Display, Formatter};
+
+pub trait Row {
+    fn cell_value(&self, column: &str) -> Option<String>;
+}
+
+pub struct Table<R> {
+    columns: Vec<Column>,
+    rows: Vec<R>,
+}
+
+struct Column {
+    name: String,
+    width: usize,
+    alignment: Alignment,
+}
+
+pub enum Alignment {
+    Left,
+    Right,
+}
+
+impl<R: Row> Table<R> {
+    pub fn new<C: AsRef<str>>(columns: &[C]) -> Table<R> {
+        let columns: Vec<Column> = columns
+            .iter()
+            .map(|name| Column {
+                name: name.as_ref().to_owned(),
+                width: name.as_ref().len(),
+                alignment: Alignment::Left,
+            })
+            .collect();
+
+        Table {
+            columns,
+            rows: vec![],
+        }
+    }
+
+    pub fn align(&mut self, column_index: usize, alignment: Alignment) {
+        self.columns[column_index].alignment = alignment;
+    }
+
+    pub fn push(&mut self, row: R) {
+        for column in self.columns.iter_mut() {
+            let len = row
+                .cell_value(column.name.as_str())
+                .map(|v| v.to_string().len())
+                .unwrap_or_default();
+            column.width = column.width.max(len);
+        }
+        self.rows.push(row);
+    }
+
+    fn header(&self, column: &Column) -> String {
+        let column_name = column.name.as_str();
+        let column_width = column.width;
+        let padding = column_width - column_name.len();
+        match column.alignment {
+            Alignment::Left => format!("{}{}", column_name, Self::right_padding(padding)),
+            Alignment::Right => format!("{}{}", Self::left_padding(padding), column_name),
+        }
+    }
+
+    fn value(&self, row: &R, column: &Column) -> String {
+        let column_name = column.name.as_str();
+        let column_value = row
+            .cell_value(column_name)
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let column_width = column.width;
+        let padding = column_width - column_value.len();
+        match column.alignment {
+            Alignment::Left => format!("{}{}", column_value, " ".repeat(padding)),
+            Alignment::Right => format!("{}{}", " ".repeat(padding), column_value),
+        }
+    }
+
+    fn left_padding(n: usize) -> String {
+        match n {
+            0 => "".to_string(),
+            1 => " ".to_string(),
+            2.. => format!("{} ", "─".repeat(n - 1)),
+        }
+    }
+
+    fn right_padding(n: usize) -> String {
+        match n {
+            0 => "".to_string(),
+            1 => " ".to_string(),
+            2.. => format!(" {}", "─".repeat(n - 1)),
+        }
+    }
+}
+
+impl<R: Row> Display for Table<R> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for column in &self.columns {
+            write!(
+                f,
+                "{}   ",
+                style(self.header(column))
+                    .yellow()
+                    .bold()
+                    .bright()
+                    .for_stdout()
+            )?;
+        }
+        writeln!(f)?;
+
+        for row in &self.rows {
+            for column in &self.columns {
+                write!(f, "{}   ", self.value(row, column))?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::table::{Alignment, Row, Table};
+
+    #[test]
+    fn render_table() {
+        struct DataPoint {
+            benchmark: &'static str,
+            result: u64,
+        }
+        impl Row for DataPoint {
+            fn cell_value(&self, column: &str) -> Option<String> {
+                match column {
+                    "A" => Some(self.benchmark.to_string()),
+                    "Result" => Some(self.result.to_string()),
+                    _ => None,
+                }
+            }
+        }
+
+        let mut table = Table::new(&["A", "Result"]);
+        table.push(DataPoint {
+            benchmark: "foo",
+            result: 10000000,
+        });
+        table.push(DataPoint {
+            benchmark: "long name",
+            result: 1,
+        });
+        table.align(0, Alignment::Left);
+        table.align(1, Alignment::Right);
+        println!("{}", table);
+    }
+}


### PR DESCRIPTION
This option is intended for quick comparisons of multiple benchmarks or for finding the right benchmark.
The command accepts basic filtering by workload or tags.

Additionally, the speed of loading reports has been significantly improved.

This feature will be enhanced in the future.