### PR TITLE
Add possibility to not store all the samples that leak memory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -382,6 +382,12 @@ pub struct RunCommand {
     #[clap(long("tag"), number_of_values = 1)]
     pub tags: Vec<String>,
 
+    /// Wether to generate final report or not. If disabled (default) then memory consumption will
+    /// be static, otherwise it will leak linearly storing samples info for a final report
+    /// calculation.
+    #[clap(long("generate-report"), required = false)]
+    pub generate_report: bool,
+
     /// Path to an output file or directory where the JSON report should be written to.
     #[clap(short('o'), long)]
     #[serde(skip)]

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -161,6 +161,7 @@ pub async fn par_execute(
     name: &str,
     exec_options: &ExecutionOptions,
     sampling: Interval,
+    store_samples: bool,
     workload: Workload,
     show_progress: bool,
 ) -> Result<BenchmarkStats> {
@@ -179,7 +180,7 @@ pub async fn par_execute(
     let progress = Arc::new(StatusLine::with_options(progress, progress_opts));
     let deadline = BoundedCycleCounter::new(exec_options.duration);
     let mut streams = Vec::with_capacity(thread_count);
-    let mut stats = Recorder::start(rate, concurrency);
+    let mut stats = Recorder::start(rate, concurrency, store_samples);
 
     for _ in 0..thread_count {
         let s = spawn_stream(

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,7 @@ async fn load(conf: LoadCommand) -> Result<()> {
         "Loading...",
         &load_options,
         config::Interval::Unbounded,
+        false,
         loader,
         !conf.quiet,
     )
@@ -242,6 +243,7 @@ async fn run(conf: RunCommand) -> Result<()> {
             "Warming up...",
             &warmup_options,
             Interval::Unbounded,
+            conf.generate_report,
             runner.clone()?,
             !conf.quiet,
         )
@@ -270,6 +272,7 @@ async fn run(conf: RunCommand) -> Result<()> {
         "Running...",
         &exec_options,
         conf.sampling_interval,
+        conf.generate_report,
         runner,
         !conf.quiet,
     )
@@ -289,19 +292,21 @@ async fn run(conf: RunCommand) -> Result<()> {
     println!();
     println!("{}", &stats_cmp);
 
-    let path = conf
-        .output
-        .clone()
-        .unwrap_or_else(|| conf.default_output_file_name("json"));
+    if stats_cmp.v1.log.len() > 1 {
+        let path = conf
+            .output
+            .clone()
+            .unwrap_or_else(|| conf.default_output_file_name("json"));
 
-    let report = Report::new(conf, stats);
-    match report.save(&path) {
-        Ok(()) => {
-            eprintln!("info: Saved report to {}", path.display());
-        }
-        Err(e) => {
-            eprintln!("error: Failed to save report to {}: {}", path.display(), e);
-            exit(1);
+        let report = Report::new(conf, stats);
+        match report.save(&path) {
+            Ok(()) => {
+                eprintln!("info: Saved report to {}", path.display());
+            }
+            Err(e) => {
+                eprintln!("error: Failed to save report to {}: {}", path.display(), e);
+                exit(1);
+            }
         }
     }
     Ok(())

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -351,17 +351,26 @@ impl Sample {
 /// Collects the samples and computes aggregate statistics
 struct Log {
     samples: Vec<Sample>,
+    samples_counter: u64,
+    store_samples: bool,
 }
 
 impl Log {
-    fn new() -> Log {
+    fn new(store_samples: bool) -> Log {
         Log {
             samples: Vec::new(),
+            samples_counter: 0,
+            store_samples,
         }
     }
 
     fn append(&mut self, sample: Sample) -> &Sample {
-        self.samples.push(sample);
+        if self.store_samples || self.samples.is_empty() {
+            self.samples.push(sample);
+        } else {
+            self.samples[0] = sample;
+        }
+        self.samples_counter += 1;
         self.samples.last().unwrap()
     }
 
@@ -473,6 +482,7 @@ pub struct BenchmarkStats {
     pub errors_ratio: Option<f64>,
     pub row_count: u64,
     pub row_count_per_req: Option<f64>,
+    pub samples_count: u64,
     pub cycle_throughput: Mean,
     pub cycle_throughput_ratio: Option<f64>,
     pub req_throughput: Mean,
@@ -569,7 +579,7 @@ impl Recorder {
     /// Creates a new recorder.
     /// The `rate_limit` and `concurrency_limit` parameters are used only as the
     /// reference levels for relative throughput and relative parallelism.
-    pub fn start(rate_limit: Option<f64>, concurrency_limit: NonZeroUsize) -> Recorder {
+    pub fn start(rate_limit: Option<f64>, concurrency_limit: NonZeroUsize, store_samples: bool) -> Recorder {
         let start_time = SystemTime::now();
         let start_instant = Instant::now();
         Recorder {
@@ -579,7 +589,7 @@ impl Recorder {
             end_instant: start_instant,
             start_cpu_time: ProcessTime::now(),
             end_cpu_time: ProcessTime::now(),
-            log: Log::new(),
+            log: Log::new(store_samples),
             rate_limit,
             concurrency_limit,
             cycle_count: 0,
@@ -661,6 +671,7 @@ impl Recorder {
             requests_per_cycle: self.request_count as f64 / self.cycle_count as f64,
             row_count: self.row_count,
             row_count_per_req: not_nan(self.row_count as f64 / self.request_count as f64),
+            samples_count: self.log.samples_counter,
             cycle_throughput,
             cycle_throughput_ratio,
             req_throughput,


### PR DESCRIPTION
It affects the possibility to generate report that requires data.
So, add new config option called `--generate-report` to cover the situation with memory leaks.

If it is set then we store all the samples as before and generate final report based on the stored data.
Side-effect - linear memory leaks.
If it is not set (default) then the samples data won't be stored and
final report won't be generated keeping stable memory consumption.

Related: https://github.com/pkolaczk/latte/issues/67