### PR TITLE
Make latte continue running even if cluster_name failed to be read

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -458,18 +458,26 @@ impl Context {
             .session
             .query(cql, ())
             .await
-            .map_err(|e| CassError::query_execution_error(cql, &[], e))?;
-        if let Some(rows) = rs.rows {
-            if let Some(row) = rows.into_iter().next() {
-                if let Ok((name, cassandra_version)) = row.into_typed() {
-                    return Ok(Some(ClusterInfo {
-                        name,
-                        cassandra_version,
-                    }));
+            .map_err(|e| CassError::query_execution_error(cql, &[], e));
+        match rs {
+            Ok(rs) => {
+                if let Some(rows) = rs.rows {
+                    if let Some(row) = rows.into_iter().next() {
+                        if let Ok((name, cassandra_version)) = row.into_typed() {
+                            return Ok(Some(ClusterInfo {
+                                name,
+                                cassandra_version,
+                            }));
+                        }
+                    }
                 }
+                Ok(None)
+            }
+            Err(e) => {
+                eprintln!("WARNING: {e}", e=e);
+                Ok(None)
             }
         }
-        Ok(None)
     }
 
     /// Prepares a statement and stores it in an internal statement map for future use.


### PR DESCRIPTION
The following error may happen having some specific cluster conditions:

```
  scylla::transport::load_balancing::default \
    Datacenter specified as the preferred one (eu-north-1) does not exist! \
      error: Cassandra error: Failed to execute query \
        "SELECT cluster_name, release_version FROM system.local" \
          with params []: Protocol Error: Empty query plan - driver bug!
```

So, this is not critical, much more valueable to continue a test run with a main stress load.

So, catch error if it happens, print it out as warning and continue with `unknown` value as a cluster name.