### PR TITLE
Add possibility to get list of datacenters in rune scripts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -484,6 +484,12 @@ impl Context {
         Ok(None)
     }
 
+    /// Returns list of datacenters used by nodes
+    pub async fn get_datacenters(&self) -> Result<Vec<String>, CassError> {
+        let dc_info = self.session.get_cluster_data().get_datacenters_info();
+        return Ok(dc_info.keys().cloned().collect());
+    }
+
     /// Prepares a statement and stores it in an internal statement map for future use.
     pub async fn prepare(&mut self, key: &str, cql: &str) -> Result<(), CassError> {
         let statement = self
@@ -1052,6 +1058,11 @@ pub fn read_resource_lines(path: &str) -> io::Result<Vec<String>> {
         .split('\n')
         .map(|s| s.to_string())
         .collect_vec())
+}
+
+#[rune::function(instance)]
+pub async fn get_datacenters(ctx: Mut<Context>) -> Result<Vec<String>, CassError> {
+    ctx.get_datacenters().await
 }
 
 #[rune::function(instance)]

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -108,6 +108,7 @@ impl Program {
     pub fn new(source: Source, params: HashMap<String, String>) -> Result<Program, LatteError> {
         let mut context_module = Module::default();
         context_module.ty::<Context>().unwrap();
+        context_module.function_meta(context::get_datacenters).unwrap();
         context_module.function_meta(context::execute).unwrap();
         context_module.function_meta(context::prepare).unwrap();
         context_module


### PR DESCRIPTION
It is useful for having better flexibility running a test against a multi-dc DB clusters.

Also, share `preferred_datacenter` info with rune scripts.