### PR TITLE
Fix blob function usage

### DIFF
--- a/src/scripting/bind.rs
+++ b/src/scripting/bind.rs
@@ -67,6 +67,14 @@ fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<CqlValue, CassError> {
             }
         }
         (Value::Bytes(v), ColumnType::Blob) => Ok(CqlValue::Blob(v.borrow_ref().unwrap().to_vec())),
+        (Value::Vec(v), ColumnType::Blob) => {
+            let v: Vec<Value> = v.borrow_ref().unwrap().to_vec();
+            let byte_vec: Vec<u8> = v
+                .into_iter()
+                .map(|value| value.as_byte().unwrap())
+                .collect();
+            Ok(CqlValue::Blob(byte_vec))
+        }
         (Value::Option(v), typ) => match v.borrow_ref().unwrap().as_ref() {
             Some(v) => to_scylla_value(v, typ),
             None => Ok(CqlValue::Empty),


### PR DESCRIPTION
In the PR (https://github.com/pkolaczk/latte/pull/96) with the switch from `rune-0.12` to `rune-0.13`
the `blob` function changed it's return type from `rune::runtime::Bytes` to the `Vec<u8>`.
Such a change required also an update to the input values parser
to expect one more input type match to the `ColumnType::Blob`.

So, add the missing parsing element to make the `blob` function work again as it was before.
It will allow to avoid manual wrapping into the
`rune::runtime::Bytes` type in rune scripts.