### PR TITLE
Update todo comment about supported data types

### DIFF
--- a/src/scripting/bind.rs
+++ b/src/scripting/bind.rs
@@ -13,8 +13,7 @@ use itertools::*;
 
 fn to_scylla_value(v: &Value, typ: &ColumnType) -> Result<CqlValue, CassError> {
     // TODO: add support for the following native CQL types:
-    //       'counter', 'date', 'decimal', 'duration', 'inet', 'time',
-    //       'timestamp', 'timeuuid' and 'variant'.
+    //       'counter', 'date', 'decimal', 'duration', 'time' and 'variant'.
     //       Also, for the 'tuple'.
     match (v, typ) {
         (Value::Bool(v), ColumnType::Boolean) => Ok(CqlValue::Boolean(*v)),


### PR DESCRIPTION
`Timestamp`, `timeuuid` and `inet` data types are already supported.
So, update approriate `todo` comment with proper list of unsupported data types.