### PR TITLE
Explain prepare as part of load and run, and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 *.iml
+latte-*
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ pub async fn schema(ctx) {
 ### Prepared statements
 
 Calling `ctx.execute` is not optimal, because it doesn't use prepared statements. You can prepare statements and
-register them on the context object in the `prepare`
-function:
+register them on the context object in the `prepare` function. 
+They will be executed during [the load step](#populating-the-database) before the actual database population.
+An example of implementing and using prepare:
 
 ```rust
 const INSERT = "my_insert";

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ pub async fn schema(ctx) {
 
 Calling `ctx.execute` is not optimal, because it doesn't use prepared statements. You can prepare statements and
 register them on the context object in the `prepare` function. 
-They will be executed during [the load step](#populating-the-database) before the actual database population.
+They will be executed during [the load step](#populating-the-database) before the actual database population 
+and the run step before executing the run function.
 An example of implementing and using prepare:
 
 ```rust


### PR DESCRIPTION
Explains that the prepare function is called during the load phase and during the run phase. 

Adds generated logs and result json files to gitignore. Can it be better to put logs and results into separate folders and ignore the folders instead?