### PR TITLE
Elide unnecessary explicit lifetimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.iml
 .idea
+.vscode

--- a/src/exec/workload.rs
+++ b/src/exec/workload.rs
@@ -44,7 +44,7 @@ impl SessionRef<'_> {
 /// possible that the underlying `Session` gets dropped before the `Value` produced by this trait
 /// implementation and the compiler is not going to catch that.
 /// The receiver of a `Value` must ensure that it is dropped before `Session`!
-impl<'a> ToValue for SessionRef<'a> {
+impl ToValue for SessionRef<'_> {
     fn to_value(self) -> VmResult<Value> {
         let obj = unsafe { AnyObj::from_ref(self.context) };
         VmResult::Ok(Value::from(vm_try!(Shared::new(obj))))
@@ -64,7 +64,7 @@ impl ContextRefMut<'_> {
 }
 
 /// Caution! See `impl ToValue for SessionRef`.
-impl<'a> ToValue for ContextRefMut<'a> {
+impl ToValue for ContextRefMut<'_> {
     fn to_value(self) -> VmResult<Value> {
         let obj = unsafe { AnyObj::from_mut(self.context) };
         VmResult::Ok(Value::from(vm_try!(Shared::new(obj))))

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -471,7 +471,7 @@ impl RunConfigCmp<'_> {
     }
 }
 
-impl<'a> Display for RunConfigCmp<'a> {
+impl Display for RunConfigCmp<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", fmt_section_header("CONFIG"))?;
         if self.v2.is_some() {
@@ -635,7 +635,7 @@ impl BenchmarkCmp<'_> {
 }
 
 /// Formats all benchmark stats
-impl<'a> Display for BenchmarkCmp<'a> {
+impl Display for BenchmarkCmp<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", fmt_section_header("SUMMARY STATS"))?;
         if self.v2.is_some() {

--- a/src/stats/histogram.rs
+++ b/src/stats/histogram.rs
@@ -28,7 +28,7 @@ impl Serialize for SerializableHistogram {
 
 struct HistogramVisitor;
 
-impl<'de> Visitor<'de> for HistogramVisitor {
+impl Visitor<'_> for HistogramVisitor {
     type Value = SerializableHistogram;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Replaces explicit lifetimes with anonymous in accordance with clippy suggestions. This unifies lifetimes usages through the codebase.

Fixes #117